### PR TITLE
feat: GET IAM credentials from instance metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 FROM python:2.7.14-alpine3.6
 MAINTAINER Renzo Meister <rm@jamotion.ch>
 
-COPY app /opt/prometheus-s3-exporter
 RUN apk add --no-cache gcc libffi-dev musl-dev openssl-dev perl py-pip python python-dev
+
+COPY app/requirements.txt /opt/prometheus-s3-exporter/requirements.txt
 RUN pip install -r /opt/prometheus-s3-exporter/requirements.txt
+
+COPY app/exporter.py /opt/prometheus-s3-exporter/exporter.py
 
 EXPOSE 9327
 VOLUME "/config"

--- a/app/exporter.py
+++ b/app/exporter.py
@@ -59,6 +59,10 @@ class S3Collector(object):
         self._s3config.update_option('use_https', use_https)
         signature = config.get('signature_v2', True)
         self._s3config.update_option('signature_v2', signature)
+
+        if len(self._s3config.access_key)==0:
+            self._s3config.role_config()
+
         self._s3 = S3(self._s3config)
 
     def collect(self):

--- a/app/exporter.py
+++ b/app/exporter.py
@@ -92,7 +92,7 @@ class S3Collector(object):
         )
         file_count_gauge = GaugeMetricFamily(
                 's3_file_count',
-                'Numbeer of existing files in folder',
+                'Number of existing files in folder',
                 labels=['folder'],
         )
         for folder in config.get('folders'):


### PR DESCRIPTION
This PR adds the ability to fetch credentials from the EC2 instance metadata endpoint by leaving the credentials blank (This relies on s3cmd version 2.1.0). 

It also optimises the Dockerfile for FS layer caching to speed up builds a bit. 